### PR TITLE
fix: CORS_ALLOWED_ORIGINS

### DIFF
--- a/currency_converter/currency_converter/settings.py
+++ b/currency_converter/currency_converter/settings.py
@@ -134,4 +134,5 @@ SPECTACULAR_SETTINGS = {
 
 # CORS_ORIGIN_ALLOW_ALL = True
 # CORS_URLS_REGEX = r'^/api/.*$'
-CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173').split(',')
+# CORS_ALLOWED_ORIGINS = os.getenv('CORS_ALLOWED_ORIGINS', 'http://localhost:5173,http://127.0.0.1:5173').split(',')
+CORS_ALLOWED_ORIGINS = 'https://currency-converter-livid-alpha.vercel.app'


### PR DESCRIPTION
Try to fix 

Access to fetch at 'https://currency-converter.hopto.org/api/convert?from=RUB&to=USD&amount=1' from origin 'https://currency-converter-livid-alpha.vercel.app' has been blocked by CORS policy: The 'Access-Control-Allow-Origin' header contains multiple values 'https://currency-converter-livid-alpha.vercel.app, http://localhost:5173, http://currency-converter-livid-alpha.vercel.app, https://currency-converter-livid-alpha.vercel.app', but only one is allowed. Have the server send the header with a valid value, or, if an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.